### PR TITLE
Create 'Menu' query and mutation endpoints

### DIFF
--- a/app/graphql/mutations/menu_create.rb
+++ b/app/graphql/mutations/menu_create.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class MenuCreate < BaseMutation
+    description "Creates a new menu"
+
+    field :menu, Types::MenuType, null: false
+
+    argument :menu_input, Types::MenuInputType, required: true
+
+    def resolve(menu_input:)
+      menu = ::Menu.new(**menu_input)
+      raise GraphQL::ExecutionError.new "Error creating menu", extensions: menu.errors.to_hash unless menu.save
+
+      { menu: menu }
+    end
+  end
+end

--- a/app/graphql/mutations/menu_delete.rb
+++ b/app/graphql/mutations/menu_delete.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class MenuDelete < BaseMutation
+    description "Deletes a menu by ID"
+
+    field :message, String, null: false
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      menu = ::Menu.find(id)
+      raise GraphQL::ExecutionError.new "Error deleting menu", extensions: menu.errors.to_hash unless menu.destroy
+
+      { message: "Menu with id: #{menu.id} is deleted successfully"}
+    end
+  end
+end

--- a/app/graphql/mutations/menu_update.rb
+++ b/app/graphql/mutations/menu_update.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Mutations
+  class MenuUpdate < BaseMutation
+    description "Updates a menu by id"
+
+    field :menu, Types::MenuType, null: false
+
+    argument :id, ID, required: true
+    argument :menu_input, Types::MenuInputType, required: true
+
+    def resolve(id:, menu_input:)
+      menu = ::Menu.find(id)
+      raise GraphQL::ExecutionError.new "Error updating menu", extensions: menu.errors.to_hash unless menu.update(**menu_input)
+
+      { menu: menu }
+    end
+  end
+end

--- a/app/graphql/types/menu_input_type.rb
+++ b/app/graphql/types/menu_input_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class MenuInputType < Types::BaseInputObject
+    argument :label, String, required: true
+    argument :state, String, required: true
+    argument :start_date, GraphQL::Types::ISO8601Date, required: true
+    argument :end_date, GraphQL::Types::ISO8601Date, required: true
+  end
+end

--- a/app/graphql/types/menu_type.rb
+++ b/app/graphql/types/menu_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class MenuType < Types::BaseObject
+    field :id, ID, null: false
+    field :label, String
+    field :state, String
+    field :start_date, GraphQL::Types::ISO8601Date
+    field :end_date, GraphQL::Types::ISO8601Date
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,11 +2,8 @@
 
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :menu_delete, mutation: Mutations::MenuDelete
+    field :menu_update, mutation: Mutations::MenuUpdate
+    field :menu_create, mutation: Mutations::MenuCreate
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,11 +21,20 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    field :menus, [Types::MenuType], null: true do
+      description "Retrieve all menus"
+    end
+
+    def menus
+      Menu.all
+    end
+
+    field :menu, Types::MenuType, null: true, description: "Retrieve menu using id" do
+      argument :id, ID, required: true
+    end
+
+    def menu(id:)
+      Menu.find(id)
     end
   end
 end


### PR DESCRIPTION
### What?

- Added necessary query and mutation types for `Menu`

### Why?

- To be able to manipulate `Menu` data with the power of GraphQL

### Screenshots

**Get all menus**
![menu_graphql](https://github.com/user-attachments/assets/5f587ffc-5b77-4492-a069-f7af9f368036)

 **Get menu by `:id`**
![menu_query_via_id](https://github.com/user-attachments/assets/c876fbb9-6d8f-4892-ac3a-f6f07cba2315)

**Update menu**
![menu_update](https://github.com/user-attachments/assets/bb8d6bfd-9ba1-4ee4-83ab-ba6c1d989175)

**Delete menu**
![menu_delete](https://github.com/user-attachments/assets/bdacaa87-d893-4aa1-a3de-8261870b0580)
