### PR TITLE
Create 'Section' query and mutation graphql endpoints

### DIFF
--- a/app/graphql/mutations/section_create.rb
+++ b/app/graphql/mutations/section_create.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class SectionCreate < BaseMutation
+    description "Creates a new section"
+
+    field :section, Types::SectionType, null: false
+
+    argument :section_input, Types::SectionInputType, required: true
+
+    def resolve(section_input:)
+      section = ::Section.new(**section_input)
+      raise GraphQL::ExecutionError.new "Error creating section", extensions: section.errors.to_hash unless section.save
+
+      { section: section }
+    end
+  end
+end

--- a/app/graphql/mutations/section_delete.rb
+++ b/app/graphql/mutations/section_delete.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class SectionDelete < BaseMutation
+    description "Deletes a section by ID"
+
+    field :message, String, null: false
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      section = ::Section.find(id)
+      raise GraphQL::ExecutionError.new "Error deleting section", extensions: section.errors.to_hash unless section.destroy
+
+      { message: "Section with id: #{section.id} is deleted successfully" }
+    end
+  end
+end

--- a/app/graphql/mutations/section_update.rb
+++ b/app/graphql/mutations/section_update.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Mutations
+  class SectionUpdate < BaseMutation
+    description "Updates a section by id"
+
+    field :section, Types::SectionType, null: false
+
+    argument :id, ID, required: true
+    argument :section_input, Types::SectionInputType, required: true
+
+    def resolve(id:, section_input:)
+      section = ::Section.find(id)
+      raise GraphQL::ExecutionError.new "Error updating section", extensions: section.errors.to_hash unless section.update(**section_input)
+
+      { section: section }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,6 +2,9 @@
 
 module Types
   class MutationType < Types::BaseObject
+    field :section_delete, mutation: Mutations::SectionDelete
+    field :section_update, mutation: Mutations::SectionUpdate
+    field :section_create, mutation: Mutations::SectionCreate
     field :menu_delete, mutation: Mutations::MenuDelete
     field :menu_update, mutation: Mutations::MenuUpdate
     field :menu_create, mutation: Mutations::MenuCreate

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -36,5 +36,22 @@ module Types
     def menu(id:)
       Menu.find(id)
     end
+
+    # Section Entity
+    field :sections, [Types::SectionType], null: true do
+      description "Retrieve all sections"
+    end
+
+    def sections
+      Section.all
+    end
+
+    field :section, Types::SectionType, null: true, description: "Retrieve section using id" do
+      argument :id, ID, required: true
+    end
+
+    def section(id:)
+      Section.find(id)
+    end
   end
 end

--- a/app/graphql/types/section_input_type.rb
+++ b/app/graphql/types/section_input_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class SectionInputType < Types::BaseInputObject
+    argument :label, String, required: true
+    argument :description, String, required: true
+  end
+end

--- a/app/graphql/types/section_type.rb
+++ b/app/graphql/types/section_type.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 module Types
-  class MenuType < Types::BaseObject
+  class SectionType < Types::BaseObject
     field :id, ID, null: false
     field :label, String
-    field :state, String
-    field :start_date, GraphQL::Types::ISO8601Date
-    field :end_date, GraphQL::Types::ISO8601Date
+    field :description, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :sections, [Types::SectionType], null: true
   end
 end


### PR DESCRIPTION
### What?

- Added necessary query and mutation types for `Section` entity

### Why?

- To be able to manipulate `Section` data with the power of GraphQL

### Screenshots

**Get all sections**
![query_all](https://github.com/user-attachments/assets/83644cc0-573a-4f26-8285-f9d1491e34e1)

 **Get section by `:id`**
![find_by_id](https://github.com/user-attachments/assets/df5a8fbf-6174-42bf-82f8-574f5e7f739e)

**Create section**
![create_endpoint](https://github.com/user-attachments/assets/9bbd05ec-ac86-4551-8dfa-343a9e156318)

**Update section**
![update](https://github.com/user-attachments/assets/ab977295-d4a3-4ca3-b675-e5de53561427)

**Delete menu**
![delete](https://github.com/user-attachments/assets/31904d10-084b-43ea-9e1c-41504c8f58a5)

**Menus with associated sections**
![menus_with_sections](https://github.com/user-attachments/assets/ace8a325-32be-478e-aeca-b2ac50e8904e)

