### PR TITLE
Create 'Item' query and mutation graphql endpoints

### DIFF
--- a/app/graphql/mutations/item_create.rb
+++ b/app/graphql/mutations/item_create.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class ItemCreate < BaseMutation
+    description "Creates a new item"
+
+    field :item, Types::ItemType, null: false
+
+    argument :item_input, Types::ItemInputType, required: true
+
+    def resolve(item_input:)
+      item = ::Item.new(**item_input)
+      raise GraphQL::ExecutionError.new "Error creating item", extensions: item.errors.to_hash unless item.save
+
+      { item: item }
+    end
+  end
+end

--- a/app/graphql/mutations/item_delete.rb
+++ b/app/graphql/mutations/item_delete.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class ItemDelete < BaseMutation
+    description "Deletes a item by ID"
+
+    field :message, String, null: false
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      item = ::Item.find(id)
+      raise GraphQL::ExecutionError.new "Error deleting item", extensions: item.errors.to_hash unless item.destroy
+
+      { message: "Item with id: #{item.id} is deleted successfully" }
+    end
+  end
+end

--- a/app/graphql/mutations/item_update.rb
+++ b/app/graphql/mutations/item_update.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Mutations
+  class ItemUpdate < BaseMutation
+    description "Updates a item by id"
+
+    field :item, Types::ItemType, null: false
+
+    argument :id, ID, required: true
+    argument :item_input, Types::ItemInputType, required: true
+
+    def resolve(id:, item_input:)
+      item = ::Item.find(id)
+      raise GraphQL::ExecutionError.new "Error updating item", extensions: item.errors.to_hash unless item.update(**item_input)
+
+      { item: item }
+    end
+  end
+end

--- a/app/graphql/types/item_input_type.rb
+++ b/app/graphql/types/item_input_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class ItemInputType < Types::BaseInputObject
+    argument :item_type, String, required: true
+    argument :label, String, required: true
+    argument :description, String, required: true
+    argument :price, Float
+  end
+end

--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class ItemType < Types::BaseObject
+    field :id, ID, null: false
+    field :item_type, String
+    field :label, String
+    field :description, String
+    field :price, Float
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,6 +2,9 @@
 
 module Types
   class MutationType < Types::BaseObject
+    field :item_delete, mutation: Mutations::ItemDelete
+    field :item_update, mutation: Mutations::ItemUpdate
+    field :item_create, mutation: Mutations::ItemCreate
     field :section_delete, mutation: Mutations::SectionDelete
     field :section_update, mutation: Mutations::SectionUpdate
     field :section_create, mutation: Mutations::SectionCreate

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -53,5 +53,22 @@ module Types
     def section(id:)
       Section.find(id)
     end
+
+    # Item Entity
+    field :items, [Types::ItemType], null: true do
+      description "Retrieve all items"
+    end
+
+    def items
+      Item.all
+    end
+
+    field :item, Types::ItemType, null: true, description: "Retrieve item using id" do
+      argument :id, ID, required: true
+    end
+
+    def item(id:)
+      Item.find(id)
+    end
   end
 end


### PR DESCRIPTION
### What?

- Added necessary query and mutation types for `Item` entity

### Why?

- To be able to manipulate `Item` data with the power of GraphQL

### Screenshots

**Get all items**
![items](https://github.com/user-attachments/assets/a56d67c4-0427-4585-9add-a119483b3bc4)

 **Get item by `:id`**
![by_id](https://github.com/user-attachments/assets/d05d1c60-de39-4f90-812b-c343825f418f)

**Create item**
![create](https://github.com/user-attachments/assets/1b6c4f6e-7d95-4eab-b727-b08acc643191)

**Update item**
![update](https://github.com/user-attachments/assets/c99ba3c2-3a51-4fa6-a4a2-e4b4cb862ff9)

**Delete item**
![delete](https://github.com/user-attachments/assets/3855e404-b109-43d2-9bd0-4145bee4a5d8)
